### PR TITLE
Feat : local_run.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_DATABASE: easyform
+      MYSQL_USER: admin
+      MYSQL_ROOT_PASSWORD: pass
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    container_name: pma
+    depends_on:
+      - mysql
+    links:
+      - mysql
+    environment:
+      PMA_HOST: mysql
+      PMA_PORT: 3306
+    ports:
+      - 8081:80
+
+volumes:
+  mysql_data:

--- a/local_run.sh
+++ b/local_run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+docker-compose build && 
+docker-compose up -d &&
+yarn install && 
+yarn start:local 


### PR DESCRIPTION
## Why need this change? 🧐
Backend 그리고 Frontend 개발 편의성을 위해 쉘 스크립트 추가 PR입니다. 

터미널 창에 해당 스크립트를 실행시 docker를 이용해 mysql, phpmyadmin 컨테이너를 만들며, 해당 작업 성공시 yarn install로 필요 모듈 설치후 yarn start:local로 API서버를 실행합니다.

## Changes made ✍🏻
1. docker-compose 파일 작성
- mysql
- phpmyadmin 

2. local_run 스크립트 작성

## Screenshot (optional) 📸
