### PR TITLE
Fix : invalid variable name

### DIFF
--- a/src/utils/common.js
+++ b/src/utils/common.js
@@ -34,8 +34,8 @@ async function generateAccessToken(ci) {
 async function generateRefreshToken(ci) {
   let payload = { ci, tokenFor: "refreshToken" };
   tokenOptions.expiresIn = "14d";
-  const accessToken = jwt.sign(payload, CRYPTO_TOKEN_KEY, tokenOptions);
-  return accessToken;
+  const refreshToken = jwt.sign(payload, CRYPTO_TOKEN_KEY, tokenOptions);
+  return refreshToken;
 }
 
 export {


### PR DESCRIPTION
## Why need this change? 🧐
- refresh token 생성 함수(generateRefreshToken)에 적절치 않은 변수명 fix PR입니다. 

<br />

## Changes made ✍🏻
- generateRefreshToken 함수에 return 값 변경
accessToken => refreshToken

<br />

## Screenshot (optional) 📸


<br />
