### PR TITLE
Feat : mysql port env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   mysql:
     image: mysql:8.0
     ports:
-      - 3306:3306
+      - 3307:3306
     environment:
       MYSQL_ROOT_PASSWORD: pass
       MYSQL_DATABASE: easyform

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -3,12 +3,13 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { readdirSync } from "fs";
 import association from "../utils/association.js";
-const { MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD, MYSQL_HOST } = process.env;
+const { MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD, MYSQL_HOST, MYSQL_PORT } =
+  process.env;
 
 const sequelize = new Sequelize(MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD, {
   dialect: "mysql",
   host: MYSQL_HOST,
-  port: 3306,
+  port: MYSQL_PORT,
 });
 
 const db = { sequelize, Sequelize };


### PR DESCRIPTION
## Why need this change? 🧐
- mysql port env설정 PR입니다.

<br />

## Changes made ✍🏻
- docker-compose mysql port 변경
3306 -> 3307 (local에 mysql이 설치되어있는 상태에서 docker로 mysql container 생성시
port로 인한 충돌방지)

<br />

## Screenshot (optional) 📸


<br />
